### PR TITLE
refactor: improve websocket type safety

### DIFF
--- a/packages/api/src/services/websocket-connection-manager.ts
+++ b/packages/api/src/services/websocket-connection-manager.ts
@@ -3,7 +3,7 @@ import { WebSocket } from 'ws';
 export interface WebSocketConnection {
   id: string;
   ws: WebSocket;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   alive: boolean;
   connectedAt: Date;
   messageQueue?: Array<{
@@ -42,7 +42,7 @@ export class WebSocketConnectionManager {
   addConnection(
     connectionId: string,
     ws: WebSocket,
-    metadata?: Record<string, any>
+    metadata?: Record<string, unknown>
   ): void {
     this.connections.set(connectionId, {
       id: connectionId,
@@ -106,7 +106,7 @@ export class WebSocketConnectionManager {
   /**
    * Get connections by metadata property
    */
-  getConnectionsByMetadata(key: string, value: any): WebSocketConnection[] {
+  getConnectionsByMetadata(key: string, value: unknown): WebSocketConnection[] {
     const result: WebSocketConnection[] = [];
     this.connections.forEach(conn => {
       if (conn.metadata?.[key] === value) {
@@ -121,7 +121,7 @@ export class WebSocketConnectionManager {
    */
   updateConnectionMetadata(
     connectionId: string,
-    metadata: Record<string, any>
+    metadata: Record<string, unknown>
   ): boolean {
     const connection = this.connections.get(connectionId);
     if (!connection) {
@@ -134,7 +134,7 @@ export class WebSocketConnectionManager {
   /**
    * Broadcast message to all connections with backpressure handling
    */
-  async broadcastToAll(message: any): Promise<void> {
+  async broadcastToAll(message: unknown): Promise<void> {
     const promises: Promise<boolean>[] = [];
 
     this.connections.forEach(conn => {
@@ -147,7 +147,7 @@ export class WebSocketConnectionManager {
   /**
    * Broadcast message to connections of a specific type with backpressure handling
    */
-  async broadcastToType(type: string, message: any): Promise<void> {
+  async broadcastToType(type: string, message: unknown): Promise<void> {
     const connections = this.getConnectionsByType(type);
     const promises: Promise<boolean>[] = [];
 
@@ -161,7 +161,10 @@ export class WebSocketConnectionManager {
   /**
    * Send message to a specific connection with backpressure handling
    */
-  async sendToConnection(connectionId: string, message: any): Promise<boolean> {
+  async sendToConnection(
+    connectionId: string,
+    message: unknown
+  ): Promise<boolean> {
     const connection = this.connections.get(connectionId);
     if (!connection || connection.ws.readyState !== WebSocket.OPEN) {
       return false;
@@ -397,7 +400,8 @@ export class WebSocketConnectionManager {
     };
 
     this.connections.forEach(conn => {
-      const type = String(conn.metadata?.type ?? 'unknown');
+      const rawType = conn.metadata?.type;
+      const type = typeof rawType === 'string' ? rawType : 'unknown';
       stats.byType[type] = (stats.byType[type] ?? 0) + 1;
     });
 

--- a/packages/shared/src/utils/redis-client.ts
+++ b/packages/shared/src/utils/redis-client.ts
@@ -297,7 +297,10 @@ export class RedisClient {
         if (!callbacks.has(channel)) {
           callbacks.set(channel, []);
         }
-        callbacks.get(channel)!.push(callback);
+        const channelCallbacks = callbacks.get(channel);
+        if (channelCallbacks) {
+          channelCallbacks.push(callback);
+        }
 
         // Subscribe to the channel if not already subscribed
         if (!subscribedChannels.has(channel)) {
@@ -411,7 +414,8 @@ export class RedisClient {
     // but using a duplicate of the internal Redis client
     const duplicateInstance = new RedisClient(this.config);
     // Replace the internal client with a duplicate
-    (duplicateInstance as any).client = this.client.duplicate();
+    (duplicateInstance as unknown as { client: RedisClientType }).client =
+      this.client.duplicate();
     return duplicateInstance;
   }
 


### PR DESCRIPTION
## Summary
- remove unsafe any usage in websocket connection manager
- register websocket plugin without any casts
- add safer Redis client duplication and channel callback handling

## Testing
- `npm run lint --workspace=@aizen/api`
- `npm run lint --workspace=@aizen/shared`
- `npm test --workspace=@aizen/api` *(fails: Redis error, database connection failed)*
- `npm run type-check --workspace=@aizen/api` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0d72ea5483279c95607a52b6b9d5