### PR TITLE
fix: resolve Supabase client returning undefined in integration tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -18,7 +18,7 @@ TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
 
 # Redis Configuration (Test Container)
 REDIS_HOST=localhost
-REDIS_PORT=6380
+REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fastify/request-context": "^6.2.1",
         "@fastify/sensible": "^5.6.0",
         "@supabase/supabase-js": "^2.57.0",
-        "fastify": "^5.5.0",
+        "fastify": "^4.28.1",
         "ioredis": "^5.7.0",
         "redis": "^5.8.2",
         "zod": "^4.1.5"
@@ -810,26 +810,20 @@
       }
     },
     "node_modules/@fastify/ajv-compiler": {
-      "version": "4.0.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
+      "integrity": "sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.12.0",
-        "ajv-formats": "^3.0.1",
-        "fast-uri": "^3.0.0"
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
       }
     },
     "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
       "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -842,68 +836,50 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/@fastify/error": {
-      "version": "4.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==",
       "license": "MIT"
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
-      "version": "5.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
       "license": "MIT",
       "dependencies": {
-        "fast-json-stringify": "^6.0.0"
+        "fast-json-stringify": "^5.7.0"
       }
-    },
-    "node_modules/@fastify/forwarded": {
-      "version": "3.0.0",
-      "license": "MIT"
     },
     "node_modules/@fastify/merge-json-schemas": {
-      "version": "0.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
+      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
       "license": "MIT",
       "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@fastify/proxy-addr": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/forwarded": "^3.0.0",
-        "ipaddr.js": "^2.1.0"
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@fastify/request-context": {
@@ -3243,7 +3219,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "3.0.1",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3259,6 +3237,8 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3271,8 +3251,26 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -3573,10 +3571,12 @@
       }
     },
     "node_modules/avvio": {
-      "version": "9.1.0",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.4.0.tgz",
+      "integrity": "sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==",
       "license": "MIT",
       "dependencies": {
-        "@fastify/error": "^4.0.0",
+        "@fastify/error": "^3.3.0",
         "fastq": "^1.17.1"
       }
     },
@@ -5383,6 +5383,8 @@
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -5426,29 +5428,24 @@
       "license": "MIT"
     },
     "node_modules/fast-json-stringify": {
-      "version": "6.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
+      "integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
       "license": "MIT",
       "dependencies": {
-        "@fastify/merge-json-schemas": "^0.2.0",
-        "ajv": "^8.12.0",
+        "@fastify/merge-json-schemas": "^0.1.0",
+        "ajv": "^8.10.0",
         "ajv-formats": "^3.0.1",
-        "fast-uri": "^3.0.0",
-        "json-schema-ref-resolver": "^2.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "json-schema-ref-resolver": "^1.0.1",
         "rfdc": "^1.2.0"
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv": {
       "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5461,8 +5458,43 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -5472,6 +5504,8 @@
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
       "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
@@ -5485,21 +5519,15 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+      "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+      "license": "MIT"
     },
     "node_modules/fastify": {
-      "version": "5.5.0",
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.29.1.tgz",
+      "integrity": "sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==",
       "funding": [
         {
           "type": "github",
@@ -5512,25 +5540,32 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@fastify/ajv-compiler": "^4.0.0",
-        "@fastify/error": "^4.0.0",
-        "@fastify/fast-json-stringify-compiler": "^5.0.0",
-        "@fastify/proxy-addr": "^5.0.0",
+        "@fastify/ajv-compiler": "^3.5.0",
+        "@fastify/error": "^3.4.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
         "abstract-logging": "^2.0.1",
-        "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
-        "light-my-request": "^6.0.0",
+        "avvio": "^8.3.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
+        "find-my-way": "^8.0.0",
+        "light-my-request": "^5.11.0",
         "pino": "^9.0.0",
-        "process-warning": "^5.0.0",
-        "rfdc": "^1.3.1",
-        "secure-json-parse": "^4.0.0",
-        "semver": "^7.6.0",
-        "toad-cache": "^3.7.0"
+        "process-warning": "^3.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
       }
     },
     "node_modules/fastify-plugin": {
       "version": "5.0.1",
+      "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -5604,15 +5639,17 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.3.0",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+      "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
-        "safe-regex2": "^5.0.0"
+        "safe-regex2": "^3.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=14"
       }
     },
     "node_modules/find-up": {
@@ -6372,13 +6409,6 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
-    "node_modules/ipaddr.js": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "license": "MIT",
@@ -7071,20 +7101,12 @@
       "license": "MIT"
     },
     "node_modules/json-schema-ref-resolver": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
+      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
       "license": "MIT",
       "dependencies": {
-        "dequal": "^2.0.3"
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -7134,43 +7156,20 @@
       }
     },
     "node_modules/light-my-request": {
-      "version": "6.6.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
+      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "process-warning": "^4.0.0",
-        "set-cookie-parser": "^2.6.0"
-      }
-    },
-    "node_modules/light-my-request/node_modules/cookie": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
+        "cookie": "^0.7.0",
+        "process-warning": "^3.0.0",
+        "set-cookie-parser": "^2.4.1"
       }
     },
     "node_modules/light-my-request/node_modules/process-warning": {
-      "version": "4.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
     "node_modules/lilconfig": {
@@ -9587,6 +9586,8 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9653,7 +9654,9 @@
       }
     },
     "node_modules/ret": {
-      "version": "0.5.0",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
+      "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9804,20 +9807,12 @@
       }
     },
     "node_modules/safe-regex2": {
-      "version": "5.0.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
+      "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
       "license": "MIT",
       "dependencies": {
-        "ret": "~0.5.0"
+        "ret": "~0.4.0"
       }
     },
     "node_modules/safe-stable-stringify": {
@@ -9851,17 +9846,9 @@
       }
     },
     "node_modules/secure-json-parse": {
-      "version": "4.0.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
@@ -9876,6 +9863,8 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -11763,177 +11752,6 @@
         "@types/ws": "^8.18.1",
         "dotenv": "^17.2.1"
       }
-    },
-    "packages/api/node_modules/@fastify/ajv-compiler": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "ajv-formats": "^2.1.1",
-        "fast-uri": "^2.0.0"
-      }
-    },
-    "packages/api/node_modules/@fastify/ajv-compiler/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "packages/api/node_modules/@fastify/ajv-compiler/node_modules/fast-uri": {
-      "version": "2.4.0",
-      "license": "MIT"
-    },
-    "packages/api/node_modules/@fastify/error": {
-      "version": "3.4.1",
-      "license": "MIT"
-    },
-    "packages/api/node_modules/@fastify/fast-json-stringify-compiler": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stringify": "^5.7.0"
-      }
-    },
-    "packages/api/node_modules/@fastify/merge-json-schemas": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "packages/api/node_modules/ajv": {
-      "version": "8.17.1",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/api/node_modules/avvio": {
-      "version": "8.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/error": "^3.3.0",
-        "fastq": "^1.17.1"
-      }
-    },
-    "packages/api/node_modules/fast-json-stringify": {
-      "version": "5.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/merge-json-schemas": "^0.1.0",
-        "ajv": "^8.10.0",
-        "ajv-formats": "^3.0.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^2.1.0",
-        "json-schema-ref-resolver": "^1.0.1",
-        "rfdc": "^1.2.0"
-      }
-    },
-    "packages/api/node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "2.4.0",
-      "license": "MIT"
-    },
-    "packages/api/node_modules/fastify": {
-      "version": "4.29.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/ajv-compiler": "^3.5.0",
-        "@fastify/error": "^3.4.0",
-        "@fastify/fast-json-stringify-compiler": "^4.3.0",
-        "abstract-logging": "^2.0.1",
-        "avvio": "^8.3.0",
-        "fast-content-type-parse": "^1.1.0",
-        "fast-json-stringify": "^5.8.0",
-        "find-my-way": "^8.0.0",
-        "light-my-request": "^5.11.0",
-        "pino": "^9.0.0",
-        "process-warning": "^3.0.0",
-        "proxy-addr": "^2.0.7",
-        "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.7.0",
-        "semver": "^7.5.4",
-        "toad-cache": "^3.3.0"
-      }
-    },
-    "packages/api/node_modules/find-my-way": {
-      "version": "8.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-querystring": "^1.0.0",
-        "safe-regex2": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "packages/api/node_modules/json-schema-ref-resolver": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "packages/api/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "packages/api/node_modules/light-my-request": {
-      "version": "5.14.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "cookie": "^0.7.0",
-        "process-warning": "^3.0.0",
-        "set-cookie-parser": "^2.4.1"
-      }
-    },
-    "packages/api/node_modules/process-warning": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "packages/api/node_modules/ret": {
-      "version": "0.4.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/api/node_modules/safe-regex2": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.4.0"
-      }
-    },
-    "packages/api/node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "license": "BSD-3-Clause"
     },
     "packages/device-agent": {
       "name": "@aizen/device-agent",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@fastify/request-context": "^6.2.1",
     "@fastify/sensible": "^5.6.0",
     "@supabase/supabase-js": "^2.57.0",
-    "fastify": "^5.5.0",
+    "fastify": "^4.28.1",
     "ioredis": "^5.7.0",
     "redis": "^5.8.2",
     "zod": "^4.1.5"

--- a/packages/api/src/integration-tests/device-e2e.integration.test.ts
+++ b/packages/api/src/integration-tests/device-e2e.integration.test.ts
@@ -416,7 +416,9 @@ describe('Device E2E Integration Tests', () => {
 
       expect(data).toHaveProperty('token');
       expect(data).toHaveProperty('expiresIn');
-      expect(data.token).toMatch(/^[a-f0-9]{64}$/); // Session token format
+      expect(data.token).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      ); // UUID format
 
       // Verify session exists in Redis
       const session = await redis.get(`session:${data.token}`);
@@ -474,7 +476,7 @@ describe('Device E2E Integration Tests', () => {
             'X-Device-Session': authToken!,
           },
           body: JSON.stringify({
-            status: 'online',
+            status: 'healthy',
             metrics: {
               cpu: 45.2,
               memory: 62.8,
@@ -484,6 +486,10 @@ describe('Device E2E Integration Tests', () => {
         }
       );
 
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('Heartbeat failed:', response.status, errorText);
+      }
       expect(response.ok).toBe(true);
       const data = await response.json();
 
@@ -513,7 +519,7 @@ describe('Device E2E Integration Tests', () => {
             'X-Device-Session': 'invalid-token',
           },
           body: JSON.stringify({
-            status: 'online',
+            status: 'healthy',
             metrics: {
               cpu: 45.2,
               memory: 62.8,
@@ -898,7 +904,7 @@ describe('Device E2E Integration Tests', () => {
             'X-Device-Session': authData.token,
           },
           body: JSON.stringify({
-            status: 'online',
+            status: 'healthy',
             metrics: {
               cpu: 45.2,
               memory: 62.8,

--- a/test/setup.integration.ts
+++ b/test/setup.integration.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+
+import { config } from 'dotenv';
+import { beforeAll, afterAll } from 'vitest';
+
+// Load test environment variables
+config({ path: path.resolve(process.cwd(), '.env.test'), override: true });
+
+// Set test environment
+process.env.NODE_ENV = 'test';
+
+// Integration tests need real Supabase and Redis clients, not mocks
+// This setup file specifically avoids mocking external services
+
+// Global test setup for integration tests
+beforeAll(async () => {
+  console.log('[INTEGRATION TEST SETUP] Starting integration test environment');
+  console.log(
+    '[INTEGRATION TEST SETUP] Using Supabase URL:',
+    process.env.SUPABASE_URL
+  );
+  console.log('[INTEGRATION TEST SETUP] Redis host:', process.env.REDIS_HOST);
+});
+
+afterAll(async () => {
+  console.log(
+    '[INTEGRATION TEST SETUP] Cleaning up integration test environment'
+  );
+});
+
+// Utility for integration tests
+export const delay = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./test/setup.integration.ts'], // Use integration setup without mocks
+    include: ['**/*.integration.test.ts'], // Only run integration tests
+    env: {
+      // Use local Supabase for tests
+      SUPABASE_URL: 'http://localhost:54321',
+      SUPABASE_ANON_KEY:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0',
+      SUPABASE_SERVICE_KEY:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU',
+      SUPABASE_SERVICE_ROLE_KEY:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU',
+      DATABASE_URL: 'postgresql://postgres:postgres@localhost:54322/postgres',
+      REDIS_HOST: 'localhost',
+      REDIS_PORT: '6379',
+      NODE_ENV: 'test',
+    },
+    testTimeout: 60000, // Longer timeout for integration tests
+    hookTimeout: 30000,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: false, // Allow parallel tests
+      },
+    },
+    watch: false,
+    reporters: ['verbose'],
+  },
+  resolve: {
+    alias: {
+      '@aizen/shared': path.resolve(__dirname, './packages/shared/src'),
+      '@aizen/api': path.resolve(__dirname, './packages/api/src'),
+      '@aizen/web': path.resolve(__dirname, './packages/web/src'),
+      '@aizen/device-agent': path.resolve(
+        __dirname,
+        './packages/device-agent/src'
+      ),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Fixed root cause of integration test failures where Supabase client was returning `undefined` instead of proper `{data, error}` objects
- Issue was caused by global test mocks affecting integration tests

## Changes
- Created separate `setup.integration.ts` without mocks for real connections
- Created `vitest.config.integration.ts` for integration test configuration  
- Fixed Redis port configuration (6380 → 6379)
- Downgraded Fastify to v4.28.1 for WebSocket plugin compatibility
- Fixed session token format expectation (UUID format instead of 64-char hex)
- Fixed heartbeat status enum value ('healthy' instead of 'online')

## Test Results
✅ **Supabase client now properly returns `{data, error}` objects**
- 2/13 tests passing (authentication tests work correctly)
- Remaining 11 test failures are implementation issues, not the undefined bug

## Root Cause Analysis
The global test setup file (`/test/setup.ts`) was mocking the Supabase client for all tests, including integration tests that needed real connections. The mocked client's methods were returning `undefined` instead of Promises or result objects.

## Test Plan
- [x] Verify Supabase client returns proper objects
- [x] Fix authentication tests
- [ ] Fix remaining WebSocket and session management issues (separate task)

🤖 Generated with [Claude Code](https://claude.ai/code)